### PR TITLE
request = request_cache in code

### DIFF
--- a/elasticsearch/client/indices.py
+++ b/elasticsearch/client/indices.py
@@ -661,7 +661,7 @@ class IndicesClient(NamespacedClient):
 
     @query_params('allow_no_indices', 'expand_wildcards', 'field_data',
         'fielddata', 'fields', 'ignore_unavailable', 'query', 'recycler',
-        'request')
+        'request_cache')
     def clear_cache(self, index=None, params=None):
         """
         Clear either all caches or specific cached associated with one ore more indices.
@@ -682,7 +682,7 @@ class IndicesClient(NamespacedClient):
             ignored when unavailable (missing or closed)
         :arg query: Clear query caches
         :arg recycler: Clear the recycler cache
-        :arg request: Clear request cache
+        :arg request_cache: Clear request cache
         """
         return self.transport.perform_request('POST', _make_path(index,
             '_cache', 'clear'), params=params)


### PR DESCRIPTION
` public static final ParseField REQUEST_CACHE = new ParseField("request_cache");`

https://github.com/elastic/elasticsearch/blob/6265ef1c1ba1d308bcc28d00dccccac555e33b89/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestClearIndicesCacheAction.java#L103

Tested under 5.1.2:

`curl -XPOST 'localhost:9200/_cache/clear?request'
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/_cache/clear] contains unrecognized parameter: [request]"}],"type":"illegal_argument_exception","reason":"request [/_cache/clear]`